### PR TITLE
Where operation fix

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -22,7 +22,7 @@ comp_dist = array([0.1, 0.1, 0.2, 0.2, 0.2, 0.2]);
 
 Q_int, states, which_composition, \
         system_sizes, cum_sizes, \
-        inf_event_row, inf_event_col \
+        inf_event_row, inf_event_col, inf_event_class \
     = build_household_population(composition_list, model_input)
 
 rhs = RateEquations(
@@ -32,7 +32,8 @@ rhs = RateEquations(
     which_composition,
     states,
     inf_event_row,
-    inf_event_col)
+    inf_event_col,
+    inf_event_class)
 
 # Initialisation
 fully_sus = where(rhs.states_sus_only.sum(axis=1) == states.sum(axis=1))[0]

--- a/examples/uk/run.py
+++ b/examples/uk/run.py
@@ -25,18 +25,18 @@ if isfile('vars.pkl') is True:
     with open('vars.pkl', 'rb') as f:
         Q_int, states, which_composition, \
                 system_sizes, cum_sizes, \
-                inf_event_row, inf_event_col \
+                inf_event_row, inf_event_col, inf_event_class \
             = load(f)
 else:
     # With the parameters chosen, we calculate Q_int:
     Q_int, states, which_composition, \
             system_sizes, cum_sizes, \
-            inf_event_row, inf_event_col \
+            inf_event_row, inf_event_col, inf_event_class \
         = build_household_population(composition_list, model_input)
     with open('vars.pkl', 'wb') as f:
         dump((
             Q_int, states, which_composition, system_sizes, cum_sizes,
-            inf_event_row, inf_event_col), f)
+            inf_event_row, inf_event_col, inf_event_class), f)
 
 rhs = RateEquations(
     model_input,
@@ -45,7 +45,8 @@ rhs = RateEquations(
     which_composition,
     states,
     inf_event_row,
-    inf_event_col)
+    inf_event_col,
+    inf_event_class)
 
 # Initialisation
 fully_sus = where(rhs.states_sus_only.sum(axis=1) == states.sum(axis=1))[0]

--- a/model/common.py
+++ b/model/common.py
@@ -196,8 +196,8 @@ def build_external_import_matrix(states, row, col, inf_class, FOI_det, FOI_undet
         old_state = states[row[i], :]
         new_state = states[col[i], :]
         # Figure out which class gets infected in this transition
-        d_vals[i] = FOI_det[row[i], inf_class[i]-1]
-        u_vals[i] = FOI_undet[row[i], inf_class[i]-1]
+        d_vals[i] = FOI_det[row[i], inf_class[i]]
+        u_vals[i] = FOI_undet[row[i], inf_class[i]]
 
     matrix_shape = (total_size, total_size)
     Q_ext_d = sparse(

--- a/model/common.py
+++ b/model/common.py
@@ -112,7 +112,8 @@ def within_household_spread(
             shape=(total_size, total_size))
         inf_event_row = concatenate((inf_event_row, s_present))
         inf_event_col = concatenate((inf_event_col, inf_to))
-        inf_event_class = concatenate((inf_event_class,i*ones((len(s_present)))))
+        inf_event_class = concatenate((inf_event_class,classes_present[i]*ones((len(s_present)))))
+        # input('Press enter to continue')
         # # disp('Infection events done')
         # # Now do exposure to detected or undetected
         det_to = zeros(len(e_present), dtype=int64)
@@ -188,7 +189,6 @@ def within_household_spread(
 def build_external_import_matrix(states, row, col, inf_class, FOI_det, FOI_undet, total_size):
     '''Gets sparse matrices containing rates of external infection in a household
     of a given type'''
-
     d_vals = zeros(len(row))
     u_vals = zeros(len(row))
 


### PR DESCRIPTION
This fix speeds up execution of the build_external_import_matrix function in model.common by getting rid of the 'where' statement which was used to find which age class a given infection event affects. Instead we now generate a list of age classes in the within_household_spread function, which we pass to build_external_import_matrix and then just read the age class from,